### PR TITLE
Py2 doesn't impl __ne__ from overridden __eq__ by default

### DIFF
--- a/mutablerecords/records.py
+++ b/mutablerecords/records.py
@@ -79,6 +79,9 @@ class RecordClass(object):
             or type(self) == type(other)
             and self._isequal_fields(other, self.__slots__))
 
+    def __ne__(self, other):
+        return not self == other
+
     def _isequal_fields(self, other, fields):
         return all(getattr(self, attr) == getattr(other, attr)
                    for attr in fields)
@@ -162,6 +165,9 @@ class RecordMeta(type):
             cls is other
             or cls.required_attributes == other.required_attributes
             and cls.optional_attributes == other.optional_attributes)
+    
+    def __ne__(self, other):
+        return not self == other
 
     def __hash__(cls):
         return hash(


### PR DESCRIPTION
Py2 doesn't impl __ne__ from overridden __eq__ by default. Py3 does. This PR adds __ne__ impl to take advantage of the implemented __eq__ function.

```py
In [35]: class A(object):
    ...:     def __init__(self, value):
    ...:         self.value = value
    ...:     def __eq__(self, other):
    ...:         print "A __eq__ called: %r == %r ?" % (self, other)
    ...:         return self.value == other.value
    ...: 

In [36]: x = A('a')

In [37]: y = A('a')

In [38]: x == y
A __eq__ called: <__main__.A object at 0x7f44500b4990> == <__main__.A object at 0x7f44501dded0> ?
Out[38]: True

In [39]: x != y
Out[39]: True
```